### PR TITLE
Automate instantiation of memory evars

### DIFF
--- a/examples/binary_search.v
+++ b/examples/binary_search.v
@@ -239,7 +239,7 @@ Proof.
             match type of HR with | (Is_true ?b) ↔ _ => rename b into bres end).
   - bv_solve.
   - bv_solve.
-  - apply Z.mod_divide; [lia|bv_solve].
+  - bv_solve.
   - bv_solve.
   - bv_solve.
   - bv_simplify_arith select (ite _ _ _ ≠ ite _ _ _).

--- a/examples/binary_search.v
+++ b/examples/binary_search.v
@@ -234,13 +234,12 @@ Proof.
 (*PROOF_START*)
   iStartProof.
   liARun.
-  liInst Hevar (Z.to_nat (bv_unsigned l + (bv_unsigned r - bv_unsigned l) `div` 2)).
-  liARun.
   Unshelve. all: prepare_sidecond.
   all: try (rename select (_ ↔ R _ _) into HR; rewrite bv_or_0_l in HR; [|done];
             match type of HR with | (Is_true ?b) ↔ _ => rename b into bres end).
   - bv_solve.
   - bv_solve.
+  - apply Z.mod_divide; [lia|bv_solve].
   - bv_solve.
   - bv_solve.
   - bv_simplify_arith select (ite _ _ _ ≠ ite _ _ _).

--- a/examples/binary_search_riscv64.v
+++ b/examples/binary_search_riscv64.v
@@ -184,12 +184,11 @@ Proof.
 (*PROOF_START*)
   iStartProof.
   liARun.
-  liInst Hevar (Z.to_nat (bv_unsigned l + (bv_unsigned r - bv_unsigned l) `div` 2)).
-  liARun.
   Unshelve. all: prepare_sidecond.
   all: try bv_solve.
   all: try (rename select (_ ↔ R _ _) into HR).
   all: try (rewrite bv_sign_extend_idemp bv_add_0_r in HR; [|done]).
+  - apply Z.mod_divide; [lia|bv_solve].
   - bv_simplify_arith select (_ >= _).
     apply: binary_search_cond_2; [solve_goal..| bv_solve].
   - bv_simplify_arith select (¬ (_ >= _)). bv_solve.

--- a/examples/binary_search_riscv64.v
+++ b/examples/binary_search_riscv64.v
@@ -188,7 +188,6 @@ Proof.
   all: try bv_solve.
   all: try (rename select (_ ↔ R _ _) into HR).
   all: try (rewrite bv_sign_extend_idemp bv_add_0_r in HR; [|done]).
-  - apply Z.mod_divide; [lia|bv_solve].
   - bv_simplify_arith select (_ >= _).
     apply: binary_search_cond_2; [solve_goal..| bv_solve].
   - bv_simplify_arith select (¬ (_ >= _)). bv_solve.

--- a/examples/hello.v
+++ b/examples/hello.v
@@ -92,8 +92,7 @@ Definition hello_spec_trace : list seq_label → Prop :=
   scons (SInstrTrap (BV 64 0x0000000010300020)) $
   snil.
 
-Definition hello_loop_spec `{!islaG Σ} `{!threadG} : iProp Σ :=
-  ∃ (i : nat),
+Definition hello_loop_spec `{!islaG Σ} `{!threadG} (i : nat): iProp Σ :=
   ⌜i + 1 < length hello_world_string⌝ ∗
   reg_col sys_regs ∗
   0x0000000010300690 ↦ₘ∗ hello_world_string ∗
@@ -106,49 +105,54 @@ Definition hello_loop_spec `{!islaG Σ} `{!threadG} : iProp Σ :=
 
 Arguments hello_loop_spec /.
 
-Lemma hello_loop `{!islaG Σ} `{!threadG} :
+Lemma Z_to_bv_eq_bv (n : N) (z : Z) (_ : BvWf n z) : Z_to_bv n z = BV n z.
+Proof. bv_solve. Qed.
+
+Lemma hello_loop `{!islaG Σ} `{!threadG} (i : nat):
+  mmio_range 0x101f1000 0x10 -∗
   instr 0x0000000010300014 (Some a14) -∗
   instr 0x0000000010300018 (Some a18) -∗
   instr 0x000000001030001c (Some a1c) -∗
   instr 0x0000000010300020 None -∗
-  □ instr_pre 0x0000000010300014 hello_loop_spec -∗
-  mmio_range 0x101f1000 0x10 -∗
-  instr_body 0x0000000010300014 hello_loop_spec.
+  □ instr_pre 0x0000000010300014 (hello_loop_spec (S i)) -∗
+  instr_body 0x0000000010300014 (hello_loop_spec i).
 Proof.
   iStartProof.
-  Time repeat liAStep; liShow.
-  erewrite drop_S; csimpl.
-  2: { apply: list_lookup_lookup_total_lt => /=. lia. }
-  Time repeat liAStep; liShow.
-  liInst Hevar (S i)%nat.
-  Time repeat liAStep; liShow.
-  liInst Hevar (S i)%nat.
-  Time repeat liAStep; liShow.
+  liARun.
+  erewrite drop_S; csimpl. 2: { apply: list_lookup_lookup_total_lt => /=. lia. }
+  liARun.
 
   Unshelve. all: prepare_sidecond.
   all: try bv_solve.
-  - rewrite lookup_total_take /=; [|lia]. bv_solve.
-  - have ? : i = 13%nat. {
-      rename select (bv_concat _ _ _ = _) into Heq.
-      revert select (_ !! i = Some vmem). move: Heq. clear => ??.
-      by repeat (destruct i; simplify_eq/=).
+  all: bv_simplify.
+  - f_equal. f_equal. repeat (destruct i; simpl; [reflexivity|]); lia.
+  - auto with zarith.
+  - have ? : i < 13%nat. {
+      repeat (destruct i; [lia|]).
+      have ?: i = 0%nat by lia. subst. simpl in H1.
+      injection H1 as ?. subst.
+      bv_simplify H3.
+      contradiction.
     }
-    subst. rewrite drop_ge //. normalize_and_simpl_goal => //. bv_solve.
-  - rename select (bv_concat _ _ _ ≠ _) into Hneq.
-    bv_simplify Hneq.
-    revert select (_ !! i = Some vmem). move: Hneq. clear => ??.
-    by repeat (destruct i; simplify_eq/=).
-  - erewrite list_lookup_total_correct; [|done]. bv_solve.
+    lia.
+  - ring_simplify (271582864 + i + 1 - 271582864) in H1. rewrite Z.div_1_r in H1.
+    apply list_lookup_total_correct in H1. subst.
+    repeat (destruct i; simpl; [bv_solve|try lia]).
+  - bv_simplify H1.
+    repeat (destruct i; [set_solver|]).
+    have ?: i = 0%nat by lia. subst.
+    rewrite Z_to_bv_eq_bv.
+    reflexivity.
 Time Qed.
 
 
-Lemma hello `{!islaG Σ} `{!threadG} :
+Lemma hello `{!islaG Σ} `{!threadG}:
   instr 0x0000000010300000 (Some a0) -∗
   instr 0x0000000010300004 (Some a4) -∗
   instr 0x0000000010300008 (Some a8) -∗
   instr 0x000000001030000c (Some ac) -∗
   instr 0x0000000010300010 (Some a10) -∗
-  □ instr_pre 0x0000000010300014 hello_loop_spec -∗
+  □ instr_pre 0x0000000010300014 (hello_loop_spec 0) -∗
   instr_body 0x0000000010300000 (
     reg_col sys_regs ∗
     0x0000000010300690 ↦ₘ∗ hello_world_string ∗
@@ -163,8 +167,6 @@ Lemma hello `{!islaG Σ} `{!threadG} :
     .
 Proof.
   iStartProof.
-  Time repeat liAStep; liShow.
-  liInst Hevar 0%nat.
   Time repeat liAStep; liShow.
   Unshelve. all: prepare_sidecond.
   all: bv_simplify; try done.

--- a/examples/memcpy.v
+++ b/examples/memcpy.v
@@ -125,7 +125,6 @@ Proof.
   all: try bv_solve.
   all: try bv_simplify_arith select (bv_extract _ _ _ ≠ _).
   all: try bv_simplify_arith select (bv_extract _ _ _ = _).
-  1,2: auto with zarith.
   - rewrite insert_length. bv_solve.
   - bv_solve.
   - bv_simplify.

--- a/examples/memcpy.v
+++ b/examples/memcpy.v
@@ -120,31 +120,28 @@ Proof.
 (*PROOF_START*)
   iStartProof.
   liARun.
-  liInst Hevar (Z.to_nat (bv_unsigned i)).
-  liARun.
-  liInst Hevar (Z.to_nat (bv_unsigned i)).
-  liARun.
 
   Unshelve. all: prepare_sidecond.
   all: try bv_solve.
   all: try bv_simplify_arith select (bv_extract _ _ _ ≠ _).
   all: try bv_simplify_arith select (bv_extract _ _ _ = _).
+  1,2: auto with zarith.
   - rewrite insert_length. bv_solve.
   - bv_solve.
   - bv_simplify.
-    rewrite (bv_wrap_small _ (bv_unsigned i + _)); [|bv_solve].
+    rewrite bv_wrap_small; [|bv_solve].
     have ->: (Z.to_nat (bv_unsigned i + 1)) = S ((Z.to_nat (bv_unsigned i))) by bv_solve.
-    erewrite take_S_r. 2: apply list_lookup_insert; bv_solve.
-    erewrite take_S_r; [|done].
-    rewrite take_insert; [|lia].
+    erewrite take_S_r. 2: { erewrite <- list_lookup_insert; do 2 f_equal; bv_solve. }
+    erewrite take_S_r. 2: { rewrite <- H6. f_equal. bv_solve. }
+    rewrite take_insert; [|bv_solve].
     f_equal; [done|]. f_equal. bv_solve.
   - bv_solve.
-  - rewrite -(take_drop (Z.to_nat (bv_unsigned i)) (<[_ := _]> dstdata)).
+  - rewrite -(take_drop (Z.to_nat (bv_unsigned i)) (<[_ := _]> _)).
     rewrite -(take_drop (Z.to_nat (bv_unsigned i)) srcdata).
     f_equal.
-    + by rewrite take_insert.
-    + erewrite drop_S. 2: { apply: list_lookup_insert. bv_solve. }
-      erewrite (drop_S srcdata); [|done].
+    + rewrite take_insert; [done|bv_solve].
+    + erewrite drop_S. 2: { erewrite <- list_lookup_insert; do 2 f_equal; bv_solve. }
+      erewrite (drop_S srcdata). 2: { rewrite <- H6. f_equal. bv_solve. }
       rewrite !drop_ge ?insert_length; [ |bv_solve..].
       f_equal. bv_solve.
 (*PROOF_END*)

--- a/examples/memcpy_riscv64.v
+++ b/examples/memcpy_riscv64.v
@@ -95,10 +95,6 @@ Proof.
 (*PROOF_START*)
   iStartProof.
   liARun.
-  liInst Hevar i.
-  liARun.
-  liInst Hevar i.
-  liARun.
   liInst Hevar5 (S i).
   liARun.
 
@@ -107,17 +103,18 @@ Proof.
   all: try bv_simplify select (bv_add n _ ≠ _).
   all: try rewrite insert_length.
   all: try bv_solve.
+  1,2: auto with zarith.
   - rewrite -(take_drop i (<[_ := _]> dstdata)).
     rewrite -(take_drop i srcdata).
     f_equal.
-    + by rewrite take_insert.
-    + erewrite drop_S. 2: { apply: list_lookup_insert. bv_solve. }
-      erewrite (drop_S srcdata); [|done].
+    + rewrite take_insert; [done|bv_solve].
+    + erewrite drop_S. 2: { erewrite <- list_lookup_insert; do 2 f_equal; bv_solve. }
+      erewrite (drop_S srcdata). 2: { rewrite <- H10. f_equal. bv_solve. }
       rewrite !drop_ge ?insert_length //; [ |bv_solve..].
       f_equal. bv_solve.
-  - erewrite take_S_r. 2: apply list_lookup_insert; bv_solve.
-    erewrite take_S_r; [|done].
-    rewrite take_insert; [|lia].
+  - erewrite take_S_r. 2: { erewrite <- list_lookup_insert; do 2 f_equal; bv_solve. }
+    erewrite take_S_r. 2: { rewrite <- H10. f_equal. bv_solve. }
+    rewrite take_insert; [|bv_solve].
     f_equal; [done|]. f_equal. bv_solve.
 (*PROOF_END*)
 Time Qed.

--- a/examples/memcpy_riscv64.v
+++ b/examples/memcpy_riscv64.v
@@ -103,7 +103,6 @@ Proof.
   all: try bv_simplify select (bv_add n _ ≠ _).
   all: try rewrite insert_length.
   all: try bv_solve.
-  1,2: auto with zarith.
   - rewrite -(take_drop i (<[_ := _]> dstdata)).
     rewrite -(take_drop i srcdata).
     f_equal.

--- a/theories/automation.v
+++ b/theories/automation.v
@@ -1459,8 +1459,9 @@ Section instances.
       match mk with
       | MKMapsTo n' vold => ⌜n' = n⌝ ∗ (bv_unsigned a ↦ₘ vnew -∗ WPasm es)
       | MKArray n' a' l =>
-          ∃ i : nat, ⌜a' = bv_unsigned a - (i * Z.of_N len)⌝ ∗ ⌜i < length l⌝%nat ∗
-          ∃ Heq : n = n', (a' ↦ₘ∗ <[i := (eq_rect n bv vnew n' Heq)]>l -∗ WPasm es)
+        ⌜(Z.of_N len | bv_unsigned a - a')⌝ ∗
+        ∃ i : nat, ⌜Z.of_nat i = (bv_unsigned a - a') / Z.of_N len⌝ ∗ ⌜i < length l⌝%nat ∗
+        ∃ Heq : n = n', (a' ↦ₘ∗ <[i := (eq_rect n bv vnew n' Heq)]>l -∗ WPasm es)
       | MKUninit a' n' =>
         ⌜a' ≤ bv_unsigned a⌝ ∗ ⌜bv_unsigned a + Z.of_N len ≤ a' + n'⌝ ∗ (
         bv_unsigned a ↦ₘ vnew -∗
@@ -1477,7 +1478,9 @@ Section instances.
   Proof.
     iDestruct 1 as (?? mk) "[HP Hcont]" => /=. case_match.
     - iDestruct "Hcont" as (->) "Hcont". iApply (wp_write_mem with "HP Hcont"); [done | lia].
-    - iDestruct "Hcont" as (i?? Heq) "Hcont". subst => /=.
+    - iDestruct "Hcont" as (? i iEq ? Heq) "Hcont". subst => /=. rename a0 into a'.
+      have {} iEq: a' = bv_unsigned a - i * Z.of_N len.
+      { rewrite iEq Z.mul_comm -Znumtheory.Zdivide_Zdiv_eq; [lia|lia|done]. }
       iApply (wp_write_mem_array with "HP [Hcont]"); [done|lia|done|done|].
       iIntros "Hl". by iApply "Hcont".
     - iDestruct "Hcont" as (??) "Hcont". subst n.
@@ -1503,8 +1506,10 @@ Section instances.
     find_in_context (FindMemMapsTo (bv_unsigned a)) (λ mk,
       match mk with
       | MKMapsTo n' vmem => ∃ Heq : n = n', (⌜(eq_rect n bv vread n' Heq) = vmem⌝ -∗ bv_unsigned a ↦ₘ vmem -∗ WPasm es)
-      | MKArray n' a' l => ∃ i : nat, ⌜a' = bv_unsigned a - (i * Z.of_N len)⌝ ∗ ⌜i < length l⌝%nat ∗
-         ∃ Heq : n = n', (∀ vmem, ⌜l !! i = Some vmem⌝ -∗ ⌜(eq_rect n bv vread n' Heq) = vmem⌝ -∗ a' ↦ₘ∗ l -∗ WPasm es)
+      | MKArray n' a' l =>
+        ⌜(Z.of_N len | bv_unsigned a - a')⌝ ∗
+        ∃ i : nat, ⌜Z.of_nat i = (bv_unsigned a - a') / Z.of_N len⌝ ∗ ⌜i < length l⌝%nat ∗
+        ∃ Heq : n = n', (∀ vmem, ⌜l !! i = Some vmem⌝ -∗ ⌜(eq_rect n bv vread n' Heq) = vmem⌝ -∗ a' ↦ₘ∗ l -∗ WPasm es)
       | MKUninit a' n' => False
       | MKMMIO a' l =>
         ⌜a' ≤ bv_unsigned a⌝ ∗ ⌜bv_unsigned a + Z.of_N len ≤ a' + l⌝ ∗
@@ -1515,7 +1520,9 @@ Section instances.
   Proof.
     iDestruct 1 as (?? mk) "[Hmem Hcont]" => /=. case_match.
     - iDestruct "Hcont" as (?) "Hcont". subst => /=. iApply (wp_read_mem with "Hmem Hcont"); [done|lia].
-    - iDestruct "Hcont" as (i?[??]%lookup_lt_is_Some_2 ?) "Hcont". subst => /=.
+    - iDestruct "Hcont" as (? i iEq [??]%lookup_lt_is_Some_2 ?) "Hcont". subst => /=. rename a0 into a'.
+      have {} iEq: a' = bv_unsigned a - i * Z.of_N len.
+      { rewrite iEq Z.mul_comm -Znumtheory.Zdivide_Zdiv_eq; [lia|lia|done]. }
       iApply (wp_read_mem_array with "Hmem [Hcont]"); [done|lia|done|done|].
       iIntros (?) "Hl". by iApply "Hcont".
     - done.

--- a/theories/automation.v
+++ b/theories/automation.v
@@ -1459,7 +1459,7 @@ Section instances.
       match mk with
       | MKMapsTo n' vold => ⌜n' = n⌝ ∗ (bv_unsigned a ↦ₘ vnew -∗ WPasm es)
       | MKArray n' a' l =>
-        ⌜(Z.of_N len | bv_unsigned a - a')⌝ ∗
+        ⌜(bv_unsigned a - a') `mod` Z.of_N len = 0⌝ ∗
         ∃ i : nat, ⌜Z.of_nat i = (bv_unsigned a - a') / Z.of_N len⌝ ∗ ⌜i < length l⌝%nat ∗
         ∃ Heq : n = n', (a' ↦ₘ∗ <[i := (eq_rect n bv vnew n' Heq)]>l -∗ WPasm es)
       | MKUninit a' n' =>
@@ -1476,11 +1476,11 @@ Section instances.
     ))
     ⊢ WPasm (WriteMem (RVal_Bool success) kind (RVal_Bits (@bv_to_bvn 64 a)) (RVal_Bits (@bv_to_bvn n vnew)) len tag ann :t: es).
   Proof.
-    iDestruct 1 as (?? mk) "[HP Hcont]" => /=. case_match.
+    iDestruct 1 as (? ? mk) "[HP Hcont]" => /=. case_match.
     - iDestruct "Hcont" as (->) "Hcont". iApply (wp_write_mem with "HP Hcont"); [done | lia].
-    - iDestruct "Hcont" as (? i iEq ? Heq) "Hcont". subst => /=. rename a0 into a'.
-      have {} iEq: a' = bv_unsigned a - i * Z.of_N len.
-      { rewrite iEq Z.mul_comm -Znumtheory.Zdivide_Zdiv_eq; [lia|lia|done]. }
+    - iDestruct "Hcont" as (? i Heqi ? Heq) "Hcont". subst => /=. rename a0 into a'.
+      have {} Heqi: a' = bv_unsigned a - i * Z.of_N len.
+      { rewrite Heqi Z.mul_comm -Z_div_exact_full_2; [lia|lia|done]. }
       iApply (wp_write_mem_array with "HP [Hcont]"); [done|lia|done|done|].
       iIntros "Hl". by iApply "Hcont".
     - iDestruct "Hcont" as (??) "Hcont". subst n.
@@ -1507,7 +1507,7 @@ Section instances.
       match mk with
       | MKMapsTo n' vmem => ∃ Heq : n = n', (⌜(eq_rect n bv vread n' Heq) = vmem⌝ -∗ bv_unsigned a ↦ₘ vmem -∗ WPasm es)
       | MKArray n' a' l =>
-        ⌜(Z.of_N len | bv_unsigned a - a')⌝ ∗
+        ⌜(bv_unsigned a - a') `mod` Z.of_N len = 0⌝ ∗
         ∃ i : nat, ⌜Z.of_nat i = (bv_unsigned a - a') / Z.of_N len⌝ ∗ ⌜i < length l⌝%nat ∗
         ∃ Heq : n = n', (∀ vmem, ⌜l !! i = Some vmem⌝ -∗ ⌜(eq_rect n bv vread n' Heq) = vmem⌝ -∗ a' ↦ₘ∗ l -∗ WPasm es)
       | MKUninit a' n' => False
@@ -1520,9 +1520,10 @@ Section instances.
   Proof.
     iDestruct 1 as (?? mk) "[Hmem Hcont]" => /=. case_match.
     - iDestruct "Hcont" as (?) "Hcont". subst => /=. iApply (wp_read_mem with "Hmem Hcont"); [done|lia].
-    - iDestruct "Hcont" as (? i iEq [??]%lookup_lt_is_Some_2 ?) "Hcont". subst => /=. rename a0 into a'.
-      have {} iEq: a' = bv_unsigned a - i * Z.of_N len.
-      { rewrite iEq Z.mul_comm -Znumtheory.Zdivide_Zdiv_eq; [lia|lia|done]. }
+    - iDestruct "Hcont" as (? i Heqi [??]%lookup_lt_is_Some_2 ?) "Hcont". subst => /=.
+      rename a0 into a'.
+      have {} Heqi: a' = bv_unsigned a - i * Z.of_N len.
+      { rewrite Heqi Z.mul_comm -Z_div_exact_full_2; [lia|lia|done]. }
       iApply (wp_read_mem_array with "Hmem [Hcont]"); [done|lia|done|done|].
       iIntros (?) "Hl". by iApply "Hcont".
     - done.


### PR DESCRIPTION
Lithium only instantiates (via unification) existential variables (evars) that are an equality like `evar = x`. Rewrite an evar equation in the reading and writing memory Lithium wp rules to this form such that many manual evar instantiations with the `liInst` tactic are not required anymore.

This adds an additional proof obligation: Showing that the number of bytes of an array element divides the address offset. This is always provable when using the pre-defined definition for address points to array. They should be provable using
 `apply Z.mod_divide; [lia|bv_solve].`

@MackieLoeffel This MR does not include any bitvector simplification automation experiments.