### PR TITLE
update cmdliner

### DIFF
--- a/frontend/main.ml
+++ b/frontend/main.ml
@@ -374,7 +374,7 @@ let opts_config : config Term.t =
     {input_file; mode}
   in
   let open Term in
-  pure build $ no_simp $ arch $ output $ def_name $ mode_flag $ coq_prefix $ j
+  const build $ no_simp $ arch $ output $ def_name $ mode_flag $ coq_prefix $ j
     $ input_file
 
 let cmd =
@@ -384,10 +384,11 @@ let cmd =
      mode, used to process and annotated object dump file."
   in
   let exits =
-    Term.exit_info ~doc:"on fatal errors." 1 ::
-    Term.default_exits
+    Cmd.Exit.info ~doc:"on fatal errors." 1 ::
+    Cmd.Exit.defaults
   in
-  (Term.(pure run $ opts_config), Term.info "islaris" ~doc ~exits ~version)
+  let info = Cmd.info "islaris" ~doc ~exits ~version in
+  let term = Term.(const run $ opts_config) in
+  Cmd.v info term
 
-let _ =
-  Term.(exit @@ eval cmd)
+let _ = exit @@ Cmd.eval cmd

--- a/islaris.opam
+++ b/islaris.opam
@@ -14,7 +14,7 @@ depends: [
   "coq-lithium" { (= "dev.2023-08-14.1.766a0051") | (= "dev") }
   "coq-stdpp-unstable"
   "coq-record-update" { (= "0.3.0") | (= "dev") }
-  "cmdliner" {= "1.0.4"}
+  "cmdliner" {>= "1.1.0"}
   "pprint"
   "integers"
   "dune" {= "3.9.1"} # dune updates like to break things so we fix a version


### PR DESCRIPTION
CN uses a newer version of cmdliner with an updated API. Bumped the min cmdliner version of Islaris to match CN's one so that we can have Islaris and CN in one opam switch and updated Islaris to also use the new cmdliner API.