### PR TITLE
MacOS Campatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ It is recommended to install the dependencies of Islaris via opam
 (version 2.0.0 or newer) into a new switch. This can be done via the
 following commands. You also need to make sure that you have the GNU
 GMP library on your system (`libgmp-dev` package on Debian),
-aarch64-linux-gnu-as (`binutils-aarch64-linux-gnu` package on Debian) and
-riscv64-linux-gnu-as (`binutils-riscv64-linux-gnu` package on Debian).
+aarch64-linux-gnu-as (`binutils-aarch64-linux-gnu` package on Debian,
+`aarch64-elf-binutils` package on MacOS) and
+riscv64-linux-gnu-as (`binutils-riscv64-linux-gnu` package on Debian, `riscv64-elf-binutils` on MacOS).
 
 ```
 opam switch create . ocaml-variants.4.14.0+options ocaml-option-flambda --no-install

--- a/frontend/config.ml
+++ b/frontend/config.ml
@@ -62,7 +62,7 @@ let pkgname : string = "islaris"
 let prefix : Filename.dirpath =
   (* Obtain a normalised path to the executable. *)
   let exe =
-    try Filename.realpath "/proc/self/exe" with Invalid_argument(_) ->
+    try Sys.executable_name  with Invalid_argument(_) ->
       panic "Unable to find an absolute path to the current executable."
   in
   (* Is it in the development repo? Find the ["_build"] directory. *)

--- a/frontend/config.ml
+++ b/frontend/config.ml
@@ -62,7 +62,7 @@ let pkgname : string = "islaris"
 let prefix : Filename.dirpath =
   (* Obtain a normalised path to the executable. *)
   let exe =
-    try Sys.executable_name  with Invalid_argument(_) ->
+    try Filename.realpath Sys.executable_name  with Invalid_argument(_) ->
       panic "Unable to find an absolute path to the current executable."
   in
   (* Is it in the development repo? Find the ["_build"] directory. *)


### PR DESCRIPTION
* read the executing file from the standard library
* add the name of GNU GMP library on MacOS to README